### PR TITLE
Conny pundit

### DIFF
--- a/app/controllers/equipment_needs_controller.rb
+++ b/app/controllers/equipment_needs_controller.rb
@@ -1,7 +1,9 @@
 class EquipmentNeedsController < ApplicationController
   def create
+    authorize @equipment_need
   end
 
   def update
+    authorize @equipment_need
   end
 end

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,7 +1,9 @@
 class HistoriesController < ApplicationController
   def create
+    authorize @history
   end
 
   def update
+    authorize @history
   end
 end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,16 +1,18 @@
 class MessagesController < ApplicationController
-  def create
+  def create # rubocop:disable Metrics/MethodLength
     @sport = Sport.find(params[:sport_id])
     @chatroom = Chatroom.find_by(name: "#{@sport.name} chatroom")
     @message = Message.new(message_params)
     @message.chatroom = @chatroom
     @message.user = current_user
+    authorize @message
     @message.save
-      ChatroomChannel.broadcast_to(
-        @chatroom,
-        render_to_string(partial: "messages/message", locals: { message: @message })
-      )
-      head :ok
+
+    ChatroomChannel.broadcast_to(
+      @chatroom,
+      render_to_string(partial: "messages/message", locals: { message: @message })
+    )
+    head :ok
   end
 
   private

--- a/app/controllers/overviews_controller.rb
+++ b/app/controllers/overviews_controller.rb
@@ -1,7 +1,9 @@
 class OverviewsController < ApplicationController
   def create
+    authorize @overview
   end
 
   def update
+    authorize @overview
   end
 end

--- a/app/controllers/rules_controller.rb
+++ b/app/controllers/rules_controller.rb
@@ -1,7 +1,9 @@
 class RulesController < ApplicationController
   def create
+    authorize @rule
   end
 
   def update
+    authorize @rule
   end
 end

--- a/app/controllers/terminologies_controller.rb
+++ b/app/controllers/terminologies_controller.rb
@@ -1,7 +1,9 @@
 class TerminologiesController < ApplicationController
   def create
+    authorize @terminology
   end
 
   def update
+    authorize @terminology
   end
 end

--- a/app/policies/equipment_need_policy.rb
+++ b/app/policies/equipment_need_policy.rb
@@ -1,0 +1,16 @@
+class EquipmentNeedPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/history_policy.rb
+++ b/app/policies/history_policy.rb
@@ -1,0 +1,16 @@
+class HistoryPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/message_policy.rb
+++ b/app/policies/message_policy.rb
@@ -1,0 +1,12 @@
+class MessagePolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    true
+  end
+end

--- a/app/policies/overview_policy.rb
+++ b/app/policies/overview_policy.rb
@@ -1,0 +1,16 @@
+class OverviewPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/rule_policy.rb
+++ b/app/policies/rule_policy.rb
@@ -1,0 +1,16 @@
+class RulePolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/policies/terminology_policy.rb
+++ b/app/policies/terminology_policy.rb
@@ -1,0 +1,16 @@
+class TerminologyPolicy < ApplicationPolicy
+  class Scope < Scope
+    # NOTE: Be explicit about which records you allow access to!
+    def resolve
+      scope.all
+    end
+  end
+
+  def create?
+    user.admin?
+  end
+
+  def update?
+    user.admin?
+  end
+end

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,6 +1,6 @@
  <div id="message-<%= message.id %>">
         <small>
-          <strong><%= @message.user.username %></strong>
+          <strong><%= @message.user %></strong>
           <i><%= message.created_at.strftime("%a %b %e at %l:%M %p") %></i>
         </small>
         <p><%= message.content %></p>

--- a/test/policies/equipment_need_policy_test.rb
+++ b/test/policies/equipment_need_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class EquipmentNeedPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/history_policy_test.rb
+++ b/test/policies/history_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class HistoryPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/message_policy_test.rb
+++ b/test/policies/message_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class MessagePolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/overview_policy_test.rb
+++ b/test/policies/overview_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class OverviewPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/rule_policy_test.rb
+++ b/test/policies/rule_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class RulePolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end

--- a/test/policies/terminology_policy_test.rb
+++ b/test/policies/terminology_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class TerminologyPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
added pundit to the equipment_need, histories, rules, terminologies, messages, and overviews model.

tested sending messages as a user --> WORKS

not tested the other models since we are missing the respective action definitions.

still missing positions {& description / famous player} controllers as a whole, pundit still needs to be implemented there when we have those.

fixed some style errors in the messages_controller